### PR TITLE
use name attribute over unavailable fqdn

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,6 +30,8 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Max: 80
+  Exclude:
+    - 'test/**/*.rb'
 
 # Offense count: 2
 Metrics/CyclomaticComplexity:

--- a/app/services/monitoring.rb
+++ b/app/services/monitoring.rb
@@ -27,23 +27,22 @@ class Monitoring
   end
 
   def set_downtime_host(host, options = {})
-    proxy_api.create_host_downtime(host.fqdn, default_downtime_options.merge(options))
+    proxy_api.create_host_downtime(host.name, default_downtime_options.merge(options))
   end
 
   def del_downtime_host(host, options = {})
-    proxy_api.remove_host_downtime(host.fqdn, default_downtime_options.merge(options))
+    proxy_api.remove_host_downtime(host.name, default_downtime_options.merge(options))
   end
 
   def create_host(host)
-    proxy_api.create_host(host.fqdn, host.monitoring_attributes)
+    proxy_api.create_host(host.name, host.monitoring_attributes)
   end
 
   def update_host(host)
-    proxy_api.update_host(host.fqdn, host.monitoring_attributes)
+    proxy_api.update_host(host.name, host.monitoring_attributes)
   end
 
   def delete_host(host)
-    # We cannot use host.fqdn here as that is delegated to primary interface that does not exist anymore
     proxy_api.delete_host(host.name)
   end
 

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -93,6 +93,14 @@ class HostTest < ActiveSupport::TestCase
         assert_includes tasks, "Set monitoring downtime for #{host}"
         assert_equal 1, tasks.size
       end
+
+      test 'should set downtime on delete with correct hostname' do
+        assert host.save
+        host.queue.clear
+        host.stubs(:skip_orchestration?).returns(false) # Enable orchestration
+        ProxyAPI::Monitoring.any_instance.expects(:create_host_downtime).with(host.name, anything).returns(true).once
+        assert host.destroy
+      end
     end
 
     test 'setMonitoring' do


### PR DESCRIPTION
Foreman delegates the fqdn to the primary interface. When a host is
deleted, the primary interface gets deleted first and the fqdn is not
available in the before_destroy callback. The host's name attribute
however is syncronized with the primary nic's name attribute.
The method Nic::Interface#normalize_name ensures that name is always a
fqdn.