### PR TITLE
use unique name for datetime form field

### DIFF
--- a/app/helpers/concerns/foreman_monitoring/hosts_helper_ext.rb
+++ b/app/helpers/concerns/foreman_monitoring/hosts_helper_ext.rb
@@ -53,10 +53,10 @@ module ForemanMonitoring
       end
     end
 
-    def datetime_f(f, attr, options = {})
+    def monitoring_datetime_f(f, attr, options = {})
       field(f, attr, options) do
         addClass options, 'form-control'
-        f.datetime_local_field attr, options
+        f.datetime_field attr, options
       end
     end
   end

--- a/app/views/hosts/_downtime_fields.html.erb
+++ b/app/views/hosts/_downtime_fields.html.erb
@@ -1,3 +1,3 @@
 <%= text_f f, :comment, :size => "col-md-5", :label => _('Comment'), :help_inline => _('Short description that explains why the downtime was set.'), :required => true %>
-<%= datetime_f f, :starttime, :size => "col-md-5", :label => _('Starttime'), :help_inline => _('Time when the downtime should start.'), :value => Time.current.strftime("%Y-%m-%dT%H:%M"), :required => true %>
-<%= datetime_f f, :endtime, :size => "col-md-5", :label => _('Endtime'), :help_inline => _('Time when the downtime should end.'), :value => Time.current.advance(:hours => 2).strftime("%Y-%m-%dT%H:%M"), :required => true %>
+<%= monitoring_datetime_f f, :starttime, :size => "col-md-5", :label => _('Starttime'), :help_inline => _('Time when the downtime should start.'), :min => DateTime.now, :value => Time.current, :required => true %>
+<%= monitoring_datetime_f f, :endtime, :size => "col-md-5", :label => _('Endtime'), :help_inline => _('Time when the downtime should end.'), :value => Time.current.advance(:hours => 2), :required => true %>


### PR DESCRIPTION
Fixes #25.

`foreman-tasks` plugin also specified a `datetime_f` helper method. This commit changes the code to prefix our helper with `monitoring_` to make sure the correct helper is called.

