### PR TITLE
Add API controller for scheduling host downtime

### DIFF
--- a/app/controllers/api/v2/downtime_controller.rb
+++ b/app/controllers/api/v2/downtime_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class DowntimeController < V2::BaseController
+      include Api::Version2
+      include ::ForemanMonitoring::FindHostByClientCert
+
+      authorize_host_by_client_cert %i[create]
+      before_action :find_host, :only => [:create]
+
+      api :POST, '/downtime', N_('Schedule host downtime')
+
+      def create
+        begin
+          @host.downtime_host(:comment => _('Host requested downtime'))
+        rescue StandardError => e
+          Foreman::Logging.exception('Failed to request downtime', e)
+          render :json => { 'message' => e.message }, :status => :unprocessable_entity
+          return
+        end
+
+        render :json => { 'message' => 'OK' }
+      end
+
+      private
+
+      def find_host
+        @host = detected_host
+
+        return true if @host
+
+        logger.info 'Denying access because no host could be detected.'
+        if User.current
+          render_error 'access_denied',
+                       :status => :forbidden,
+                       :locals => {
+                         :details => 'You need to authenticate with a valid client cert. The DN has to match a known host.'
+                       }
+        else
+          render_error 'unauthorized',
+                       :status => :unauthorized,
+                       :locals => {
+                         :user_login => get_client_cert_hostname
+                       }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/foreman_monitoring/find_host_by_client_cert.rb
+++ b/app/controllers/concerns/foreman_monitoring/find_host_by_client_cert.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module ForemanMonitoring
+  module FindHostByClientCert
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def authorize_host_by_client_cert(actions, _options = {})
+        skip_before_action :require_login, :only => actions, :raise => false
+        skip_before_action :authorize, :only => actions
+        skip_before_action :verify_authenticity_token, :only => actions
+        skip_before_action :set_taxonomy, :only => actions, :raise => false
+        skip_before_action :session_expiry, :update_activity_time, :only => actions
+        before_action(:only => actions) { require_client_cert_or_login }
+        attr_reader :detected_host
+      end
+    end
+
+    private
+
+    # Permits Hosts authorized by their client cert
+    # or a user with permission
+    def require_client_cert_or_login
+      @detected_host = find_host_by_client_cert
+
+      if detected_host
+        set_admin_user
+        return true
+      end
+
+      require_login
+      unless User.current
+        render_error 'unauthorized', :status => :unauthorized unless performed? && api_request?
+        return false
+      end
+      authorize
+    end
+
+    def find_host_by_client_cert
+      hostname = get_client_cert_hostname
+
+      return unless hostname
+
+      host ||= Host::Base.find_by(certname: hostname) ||
+               Host::Base.find_by(name: hostname)
+      logger.info { "Found Host #{host} by client cert #{hostname}" } if host
+      host
+    end
+
+    def get_client_cert_hostname
+      verify = request.env[Setting[:ssl_client_verify_env]]
+      unless verify == 'SUCCESS'
+        logger.info { "Client certificate is invalid: #{verify}" }
+        return
+      end
+
+      dn = request.env[Setting[:ssl_client_dn_env]]
+      return unless dn && dn =~ %r{CN=([^\s\/,]+)}i
+
+      hostname = Regexp.last_match(1).downcase
+      logger.debug "Extracted hostname '#{hostname}' from client certificate."
+      hostname
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
                      :apiv => /v1|v2/,
                      :constraints => ApiConstraints.new(:version => 2) do
       resources :monitoring_results, :only => [:create]
+      resources :downtime, :only => [:create]
     end
   end
 

--- a/lib/foreman_monitoring/engine.rb
+++ b/lib/foreman_monitoring/engine.rb
@@ -39,7 +39,7 @@ module ForemanMonitoring
                      {},
                      :resource_type => 'Host'
           permission :manage_host_downtimes,
-                     { :hosts => [:downtime, :select_multiple_downtime, :update_multiple_downtime] },
+                     { :hosts => [:downtime, :select_multiple_downtime, :update_multiple_downtime], :'api/v2/downtime' => [:create] },
                      :resource_type => 'Host'
           permission :upload_monitoring_results,
                      :'api/v2/monitoring_results' => [:create]

--- a/test/controllers/api/v2/downtime_controller_test.rb
+++ b/test/controllers/api/v2/downtime_controller_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+class Api::V2::DowntimeControllerTest < ActionController::TestCase
+  let(:host1) { as_admin { FactoryBot.create(:host, :managed) } }
+
+  context 'with user authentication' do
+    context '#create' do
+      test 'should deny access' do
+        put :create
+        assert_response :forbidden
+      end
+    end
+  end
+
+  context 'with client cert' do
+    setup do
+      User.current = nil
+      reset_api_credentials
+
+      Setting[:ssl_client_dn_env] = 'SSL_CLIENT_S_DN'
+      Setting[:ssl_client_verify_env] = 'SSL_CLIENT_VERIFY'
+
+      @request.env['HTTPS'] = 'on'
+      @request.env['SSL_CLIENT_S_DN'] = "CN=#{host1.name},DN=example,DN=com"
+      @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
+    end
+
+    context '#create' do
+      test 'should create downtime' do
+        put :create
+        assert_response :success
+      end
+    end
+  end
+
+  context 'without any credentials' do
+    setup do
+      User.current = nil
+      reset_api_credentials
+    end
+
+    context '#create' do
+      test 'should deny access' do
+        post :create
+        assert_response :unauthorized
+      end
+    end
+  end
+end


### PR DESCRIPTION
People at work suddenly came with a request for a host-authorized endpoint to allow for dynamically scheduling downtimes on the host that calls it, and as that link was already set up in Foreman, this seemed like a perfect place to add said feature.

This also copies over the `authorize_host_by_client_cert` feature from [foreman_dlm](https://github.com/dm-drogeriemarkt/foreman_dlm) in order to allow hosts to request downtime through Foreman.  
Perhaps something that might be worth promoting into core, as with this PR there'd be more than one plugin that uses it. :smiley: