### PR TITLE
fix rubocop hash alignment

### DIFF
--- a/app/helpers/concerns/foreman_monitoring/hosts_helper_ext.rb
+++ b/app/helpers/concerns/foreman_monitoring/hosts_helper_ext.rb
@@ -16,10 +16,10 @@ module ForemanMonitoring
                                                                            :anchor => 'set_host_downtime'),
                                      :class => 'btn btn-default',
                                      :disabled => !host.monitored?,
-                                     :title    => _('Set a downtime for this host'),
-                                     :id       => 'host-downtime',
-                                     :data     => { :toggle => 'modal',
-                                                    :target => '#set_host_downtime' })
+                                     :title => _('Set a downtime for this host'),
+                                     :id => 'host-downtime',
+                                     :data => { :toggle => 'modal',
+                                                :target => '#set_host_downtime' })
         )
       )
       super

--- a/app/models/concerns/orchestration/monitoring.rb
+++ b/app/models/concerns/orchestration/monitoring.rb
@@ -18,7 +18,7 @@ module Orchestration::Monitoring
   def queue_monitoring_create
     return true unless ::Monitoring.create_action?(:create)
 
-    queue.create(:name   => _('Create monitoring object for %s') % self, :priority => 20,
+    queue.create(:name => _('Create monitoring object for %s') % self, :priority => 20,
                  :action => [self, :setMonitoring])
   end
 
@@ -28,7 +28,7 @@ module Orchestration::Monitoring
     Rails.logger.debug('Detected a change to the monitoring object is required.')
     return unless ::Monitoring.create_action?(:create)
 
-    queue.create(:name   => _('Monitoring update for %s') % old, :priority => 2,
+    queue.create(:name => _('Monitoring update for %s') % old, :priority => 2,
                  :action => [self, :setMonitoringUpdate])
   end
 
@@ -36,12 +36,12 @@ module Orchestration::Monitoring
     return unless monitored? && errors.empty?
 
     if ::Monitoring.delete_action?(:delete)
-      queue.create(:name   => _('Removing monitoring object for %s') % self, :priority => 2,
+      queue.create(:name => _('Removing monitoring object for %s') % self, :priority => 2,
                    :action => [self, :delMonitoring])
     end
     return unless ::Monitoring.delete_action?(:downtime)
 
-    queue.create(:name   => _('Set monitoring downtime for %s') % self, :priority => 2,
+    queue.create(:name => _('Set monitoring downtime for %s') % self, :priority => 2,
                  :action => [self, :setMonitoringDowntime])
   end
 

--- a/app/overrides/add_host_monitoring_result_tab.rb
+++ b/app/overrides/add_host_monitoring_result_tab.rb
@@ -1,9 +1,9 @@
-Deface::Override.new(:virtual_path  => 'hosts/show',
-                     :name          => 'add_monitoring_result_tab',
+Deface::Override.new(:virtual_path => 'hosts/show',
+                     :name => 'add_monitoring_result_tab',
                      :insert_bottom => 'ul.nav-tabs',
-                     :partial       => 'monitoring_results/host_tab')
+                     :partial => 'monitoring_results/host_tab')
 
-Deface::Override.new(:virtual_path  => 'hosts/show',
-                     :name          => 'add_monitoring_result_tab_pane',
+Deface::Override.new(:virtual_path => 'hosts/show',
+                     :name => 'add_monitoring_result_tab_pane',
                      :insert_bottom => 'div.tab-content',
-                     :partial       => 'monitoring_results/host_tab_pane')
+                     :partial => 'monitoring_results/host_tab_pane')

--- a/app/overrides/add_host_multiple_power_set_downtime_checkbox.rb
+++ b/app/overrides/add_host_multiple_power_set_downtime_checkbox.rb
@@ -1,4 +1,4 @@
-Deface::Override.new(:virtual_path  => 'hosts/select_multiple_power_state',
-                     :name          => 'add_host_multiple_power_set_downtime_checkbox',
+Deface::Override.new(:virtual_path => 'hosts/select_multiple_power_state',
+                     :name => 'add_host_multiple_power_set_downtime_checkbox',
                      :insert_before => "erb[silent]:contains('end')",
-                     :partial       => 'hosts/host_downtime_checkbox')
+                     :partial => 'hosts/host_downtime_checkbox')

--- a/app/overrides/add_host_set_downtime_modal.rb
+++ b/app/overrides/add_host_set_downtime_modal.rb
@@ -1,4 +1,4 @@
-Deface::Override.new(:virtual_path  => 'hosts/show',
-                     :name          => 'add_monitoring_set_downtime_modal',
+Deface::Override.new(:virtual_path => 'hosts/show',
+                     :name => 'add_monitoring_set_downtime_modal',
                      :insert_after => 'div#review_before_build',
                      :partial => 'hosts/set_host_downtime')

--- a/foreman_monitoring.gemspec
+++ b/foreman_monitoring.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'rubocop', '~> 0.59.2'
+  s.add_development_dependency 'rubocop', '~> 0.64.0'
   s.add_dependency 'deface', '< 2.0'
 end

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -22,9 +22,9 @@ class HostsControllerExtensionsTest < ActionController::TestCase
           params: {
             :id => @host.name,
             :downtime => {
-              :comment   => 'Maintenance work.',
+              :comment => 'Maintenance work.',
               :starttime => Time.current,
-              :endtime   => Time.current.advance(:hours => 2)
+              :endtime => Time.current.advance(:hours => 2)
             }
           },
           session: set_session_user
@@ -58,9 +58,9 @@ class HostsControllerExtensionsTest < ActionController::TestCase
           params: {
             :id => @host.name,
             :downtime => {
-              :comment   => 'Maintenance work.',
+              :comment => 'Maintenance work.',
               :starttime => 'invalid',
-              :endtime   => 'invalid'
+              :endtime => 'invalid'
             }
           },
           session: set_session_user
@@ -78,9 +78,9 @@ class HostsControllerExtensionsTest < ActionController::TestCase
           params: {
             :id => @host.name,
             :downtime => {
-              :comment   => 'Maintenance work.',
+              :comment => 'Maintenance work.',
               :starttime => '2017-04-20T10:15',
-              :endtime   => '2017-04-20T12:15'
+              :endtime => '2017-04-20T12:15'
             }
           },
           session: set_session_user


### PR DESCRIPTION
Trying to fix the "Align the elements of a hash literal if they span more than one line." messages