### PR TITLE
Fix some modern RuboCop complaints

### DIFF
--- a/app/models/monitoring_result.rb
+++ b/app/models/monitoring_result.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MonitoringResult < ApplicationRecord
-  enum :result => %i[ok warning critical unknown]
+  enum :result => { :ok => 0, :warning => 1, :critical => 2, :unknown => 3 }
 
   belongs_to_host
 

--- a/foreman_monitoring.gemspec
+++ b/foreman_monitoring.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'rubocop', '~> 0.71.0'
+  s.add_development_dependency 'rubocop', '~> 0.75.0'
   s.add_dependency 'deface', '< 2.0'
 end

--- a/lib/foreman_monitoring/engine.rb
+++ b/lib/foreman_monitoring/engine.rb
@@ -75,10 +75,10 @@ module ForemanMonitoring
 
     config.to_prepare do
       begin
-        ::Host::Managed.send(:prepend, ForemanMonitoring::HostExtensions)
-        ::Hostgroup.send(:include, ForemanMonitoring::HostgroupExtensions)
-        ::HostsHelper.send(:prepend, ForemanMonitoring::HostsHelperExt)
-        ::HostsController.send(:prepend, ForemanMonitoring::HostsControllerExtensions)
+        ::Host::Managed.prepend(ForemanMonitoring::HostExtensions)
+        ::Hostgroup.include(ForemanMonitoring::HostgroupExtensions)
+        ::HostsHelper.prepend(ForemanMonitoring::HostsHelperExt)
+        ::HostsController.prepend(ForemanMonitoring::HostsControllerExtensions)
       rescue StandardError => e
         Rails.logger.warn "ForemanMonitoring: skipping engine hook (#{e})"
       end


### PR DESCRIPTION
This fixes `Lint/SendWithMixinArgument` for `lib/foreman_monitoring/engine.rb`
and `Rails/EnumHash` for `app/models/monitoring_result.rb`