### PR TITLE
Fix issue with duration as string for downtime

### DIFF
--- a/app/controllers/api/v2/downtime_controller.rb
+++ b/app/controllers/api/v2/downtime_controller.rb
@@ -20,7 +20,7 @@ module Api
           }
           if downtime_params.key? :duration
             options[:start_time] = Time.now.to_i
-            options[:end_time] = Time.now.to_i + downtime_params[:duration]
+            options[:end_time] = Time.now.to_i + downtime_params[:duration].to_i
           end
           @host.downtime_host(options)
         rescue StandardError => e

--- a/test/controllers/api/v2/downtime_controller_test.rb
+++ b/test/controllers/api/v2/downtime_controller_test.rb
@@ -40,6 +40,12 @@ class Api::V2::DowntimeControllerTest < ActionController::TestCase
         put :create, params: { duration: 3600 }
         assert_response :success
       end
+
+      test 'should create downtime with given duration as string' do
+        Host::Managed.any_instance.expects(:downtime_host).with { |params| params[:end_time] - params[:start_time] == 3600 }
+        put :create, params: { duration: '3600' }
+        assert_response :success
+      end
     end
 
     context '#create with reason' do


### PR DESCRIPTION
Seems like I unfortunately lost a `#to_i` call when transcribing the feature from the messy internal code we've been using, oops.