### PR TITLE
Use the parsed virtual fact provided by 1.24

### DIFF
--- a/app/models/concerns/foreman_monitoring/host_extensions.rb
+++ b/app/models/concerns/foreman_monitoring/host_extensions.rb
@@ -62,7 +62,7 @@ module ForemanMonitoring
         :architecture => architecture.try(:name),
         :os => operatingsystem.try(:to_label),
         :osfamily => operatingsystem.try(:family),
-        :virtual => provider != 'BareMetal',
+        :virtual => virtual.presence || provider != 'BareMetal',
         :provider => provider,
         :compute_resource => compute_resource.try(:to_label),
         :hostgroup => hostgroup.try(:to_label),


### PR DESCRIPTION
Foreman 1.24 introduced an extended the reported data facets with whether a host is virtual. This is more reliable than the provider since not everyone is using the compute resource integration.