### PR TITLE
Fixes #28985 - Add description to plugin roles

### DIFF
--- a/lib/foreman_monitoring/engine.rb
+++ b/lib/foreman_monitoring/engine.rb
@@ -51,8 +51,8 @@ module ForemanMonitoring
           'hosts/update_multiple_monitoring_proxy'
         ]
 
-        role 'Monitoring viewer', [:view_monitoring_results]
-        role 'Monitoring manager', [:view_monitoring_results, :manage_downtime_hosts]
+        role 'Monitoring viewer', [:view_monitoring_results], 'TODO'
+        role 'Monitoring manager', [:view_monitoring_results, :manage_downtime_hosts], 'TODO'
 
         register_custom_status HostStatus::MonitoringStatus
 

--- a/lib/foreman_monitoring/engine.rb
+++ b/lib/foreman_monitoring/engine.rb
@@ -51,8 +51,8 @@ module ForemanMonitoring
           'hosts/update_multiple_monitoring_proxy'
         ]
 
-        role 'Monitoring viewer', [:view_monitoring_results], 'TODO'
-        role 'Monitoring manager', [:view_monitoring_results, :manage_downtime_hosts], 'TODO'
+        role 'Monitoring viewer', [:view_monitoring_results], 'Role granting permissions to view monitor results'
+        role 'Monitoring manager', [:view_monitoring_results, :manage_downtime_hosts], 'Role granting permissions to view monitor results and manage downtimes'
 
         register_custom_status HostStatus::MonitoringStatus
 


### PR DESCRIPTION
PR is part of  [Add default descriptions to all roles added from plugins](https://projects.theforeman.org/issues/28936) task.