### PR TITLE
Fixes #31088 - Only rename permissions if the table is there

### DIFF
--- a/db/migrate/201910180900_rename_downtime_host_permission.rb
+++ b/db/migrate/201910180900_rename_downtime_host_permission.rb
@@ -3,13 +3,13 @@
 class RenameDowntimeHostPermission < ActiveRecord::Migration[5.2]
   def up
     # rubocop:disable Rails/SkipsModelValidations
-    Permission.where(name: 'manage_host_downtimes').update_all(name: 'manage_downtime_hosts')
+    Permission.where(name: 'manage_host_downtimes').update_all(name: 'manage_downtime_hosts') if table_exists?(:permissions)
     # rubocop:enable Rails/SkipsModelValidations
   end
 
   def down
     # rubocop:disable Rails/SkipsModelValidations
-    Permission.where(name: 'manage_downtime_hosts').update_all(name: 'manage_host_downtimes')
+    Permission.where(name: 'manage_downtime_hosts').update_all(name: 'manage_host_downtimes') if table_exists?(:permissions)
     # rubocop:enable Rails/SkipsModelValidations
   end
 end


### PR DESCRIPTION
For some reason this migration sometimes runs before core migrations, causing it to fail due to the table not existing yet.