### PR TITLE
use a `proc {}` for collections in settings

### DIFF
--- a/lib/foreman_monitoring/engine.rb
+++ b/lib/foreman_monitoring/engine.rb
@@ -34,13 +34,13 @@ module ForemanMonitoring
                     description: N_('What action should be taken when a host is created'),
                     default: 'create',
                     full_name: N_('Host Create Action'),
-                    collection: ::Monitoring::CREATE_ACTIONS)
+                    collection: proc { ::Monitoring::CREATE_ACTIONS })
             setting('monitoring_delete_action',
                     type: :string,
                     description: N_('What action should be taken when a host is deleted'),
                     default: 'delete',
                     full_name: N_('Host Delete Action'),
-                    collection: ::Monitoring::DELETE_ACTIONS)
+                    collection: proc { ::Monitoring::DELETE_ACTIONS })
           end
         end
 


### PR DESCRIPTION
this was forgotten when migrating from old settings, but without it you get errors like

    undefined method `call' for {"none"=>"None", "create"=>"Create Host Object"}:Hash

Fixes: 021ecc26654d2a7d21a8a60ebd9ff53b7db15c26