### PR TITLE
Use `${{ github.ref_name }}-${{ github.workflow }}` as concurency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref_name }}-${{ github.workflow }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,6 @@ concurrency:
   group: ${{ github.ref_name }}-${{ github.workflow }}
   cancel-in-progress: true
 
-env:
-  RAILS_ENV: test
-  DATABASE_URL: postgresql://postgres:@localhost/test
-  DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: true
-
 jobs:
   rubocop:
     uses: theforeman/actions/.github/workflows/rubocop.yml@v0


### PR DESCRIPTION
`head_ref` doesn't exist for push-triggered runs