### PR TITLE
Enable scoped_search for monitoring_proxy

### DIFF
--- a/app/models/concerns/foreman_monitoring/host_extensions.rb
+++ b/app/models/concerns/foreman_monitoring/host_extensions.rb
@@ -9,6 +9,8 @@ module ForemanMonitoring
         after_build :downtime_host_build
 
         has_many :monitoring_results, :dependent => :destroy, :foreign_key => 'host_id', :inverse_of => :host
+
+        scoped_search :relation => :monitoring_proxy, :on => :name, :complete_value => true, :rename => :monitoring_proxy, :only_explicit => true
       end
     end
 


### PR DESCRIPTION
We want to be able to easily search Hosts without any monitoring_proxy set